### PR TITLE
feat(seo): phase 1 crawl/index — robots, sitemap, canonicals, ISR

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -6,7 +6,7 @@ import { buildPageMetadata } from "@/lib/metadata";
 import { getContentRepository } from "@/content/repository";
 import { toPresentationProfile } from "@/content/presentation";
 
-export const dynamic = "force-dynamic";
+export const revalidate = 3600;
 
 export async function generateMetadata(): Promise<Metadata> {
   const repository = await getContentRepository();

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -6,7 +6,7 @@ import { buildPageMetadata } from "@/lib/metadata";
 import { getContentRepository } from "@/content/repository";
 import { toPresentationProfile } from "@/content/presentation";
 
-export const dynamic = "force-dynamic";
+export const revalidate = 3600;
 
 export async function generateMetadata(): Promise<Metadata> {
   const repository = await getContentRepository();

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,7 +1,7 @@
 import type { Metadata, Viewport } from "next";
 import { Prompt, Space_Grotesk, Space_Mono } from "next/font/google";
 import AppShell from "@/components/layout/AppShell.jsx";
-import { getSiteSeoDefaults, getRealContentImage, SITE_NAME, SITE_URL } from "@/config/seo.js";
+import { getSiteSeoDefaults, getRealContentImage, normalizeMetaDescription, SITE_NAME, SITE_URL } from "@/config/seo.js";
 import { buildOgImageUrl } from "@/lib/metadata";
 import { getContentRepository } from "@/content/repository";
 import { toPresentationProfile } from "@/content/presentation";
@@ -38,12 +38,11 @@ export async function generateMetadata(): Promise<Metadata> {
     metadataBase: new URL(SITE_URL),
     applicationName: SITE_NAME,
     title: { default: seo.title, template: `%s | ${SITE_NAME}` },
-    description: seo.description,
+    description: normalizeMetaDescription(seo.description, 160),
     authors: [{ name: profile.name, url: SITE_URL }],
     creator: profile.name,
     publisher: SITE_NAME,
     manifest: "/manifest.json",
-    alternates: { canonical: "/" },
     openGraph: {
       type: "website",
       url: SITE_URL,

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -3,7 +3,7 @@ import type { Metadata } from "next";
 import { buildPageMetadata } from "@/lib/metadata";
 
 export const metadata: Metadata = buildPageMetadata({
-  title: "Page Not Found | Napatdev",
+  title: "Page Not Found",
   description: "The requested page was not found on Napatdev, the portfolio of Napat Pamornsut (ณภัทร ภมรสูตร).",
   path: "/404",
   noindex: true,

--- a/app/notes/[slug]/page.tsx
+++ b/app/notes/[slug]/page.tsx
@@ -7,8 +7,14 @@ import { getNoteSchema, getNoteSeoMeta } from "@/lib/notes";
 import { getContentRepository } from "@/content/repository";
 import { toPresentationNote, toPresentationProfile } from "@/content/presentation";
 
-export const dynamic = "force-dynamic";
+export const revalidate = 3600;
 export const dynamicParams = true;
+
+export async function generateStaticParams() {
+  const repository = await getContentRepository();
+  const notes = await repository.listPublishedNotes();
+  return notes.map((note) => ({ slug: note.slug }));
+}
 
 type Props = {
   params: Promise<{ slug: string }>;

--- a/app/notes/page.tsx
+++ b/app/notes/page.tsx
@@ -7,7 +7,7 @@ import { getNotesListSeoMeta } from "@/config/seo.js";
 import { getContentRepository } from "@/content/repository";
 import { toPresentationNote, toPresentationProfile } from "@/content/presentation";
 
-export const dynamic = "force-dynamic";
+export const revalidate = 1800;
 
 export async function generateMetadata(): Promise<Metadata> {
   const repository = await getContentRepository();

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -6,7 +6,7 @@ import { buildPageMetadata } from "@/lib/metadata";
 import { getContentRepository } from "@/content/repository";
 import { toPresentationProfile } from "@/content/presentation";
 
-export const dynamic = "force-dynamic";
+export const revalidate = 3600;
 
 export async function generateMetadata(): Promise<Metadata> {
   const repository = await getContentRepository();

--- a/app/projects/[slug]/page.tsx
+++ b/app/projects/[slug]/page.tsx
@@ -7,8 +7,14 @@ import { buildPageMetadata } from "@/lib/metadata";
 import { getContentRepository } from "@/content/repository";
 import { toPresentationProfile, toPresentationProject } from "@/content/presentation";
 
-export const dynamic = "force-dynamic";
+export const revalidate = 3600;
 export const dynamicParams = true;
+
+export async function generateStaticParams() {
+  const repository = await getContentRepository();
+  const projects = await repository.listPublishedProjects();
+  return projects.map((project) => ({ slug: project.slug }));
+}
 
 type Props = {
   params: Promise<{ slug: string }>;

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -6,7 +6,7 @@ import { buildPageMetadata } from "@/lib/metadata";
 import { getContentRepository } from "@/content/repository";
 import { toPresentationProfile, toPresentationProject } from "@/content/presentation";
 
-export const dynamic = "force-dynamic";
+export const revalidate = 1800;
 
 export async function generateMetadata(): Promise<Metadata> {
   const repository = await getContentRepository();

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -6,8 +6,13 @@ export default function robots(): MetadataRoute.Robots {
     rules: [
       {
         userAgent: "*",
-        allow: "/",
-        disallow: ["/api/", "/admin", "/preview"],
+        allow: ["/", "/api/og"],
+        disallow: ["/admin", "/preview", "/api/admin/", "/api/auth/"],
+      },
+      {
+        userAgent: ["GPTBot", "ClaudeBot", "PerplexityBot", "GoogleOther"],
+        allow: ["/", "/api/og"],
+        disallow: ["/admin", "/preview", "/api/admin/", "/api/auth/"],
       },
     ],
     sitemap: `${SITE_URL}/sitemap.xml`,

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -2,7 +2,7 @@ import type { MetadataRoute } from "next";
 import { SITE_URL } from "@/config/seo.js";
 import { getContentRepository } from "@/content/repository";
 
-export const dynamic = "force-dynamic";
+export const revalidate = 3600;
 
 type SitemapEntry = {
   url: string;
@@ -40,7 +40,6 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     route("/contact", 0.85, "monthly"),
     route("/projects", 0.95, "weekly"),
     route("/notes", 0.8, "weekly"),
-    route("/search", 0.7, "weekly"),
     ...projects.map((project) =>
       route(`/projects/${project.slug}`, 0.8, "monthly", project.revision.publishedAt),
     ),

--- a/src/lib/metadata.ts
+++ b/src/lib/metadata.ts
@@ -145,7 +145,7 @@ export function buildPageMetadata({
     publisher: SITE_NAME,
     category: "Portfolio",
     keywords,
-    alternates: {
+    alternates: noindex ? undefined : {
       canonical,
     },
     robots: noindex


### PR DESCRIPTION
Closes #33. Coordinates with #29 (implements its ISR scope).

## What
- robots.ts: stop blocking /api/og (narrow disallow to /admin, /preview, /api/admin/, /api/auth/), explicit Allow for GPTBot/ClaudeBot/PerplexityBot/GoogleOther
- sitemap.ts: drop /search (thin/noindex surface), force-dynamic -> revalidate 3600
- Canonicals: remove layout-level canonical / (page-level only), omit canonical on noindex pages, fix not-found double brand suffix
- ISR: /,/about,/contact revalidate 3600; /projects,/notes 1800; slug routes generateStaticParams + dynamicParams + revalidate 3600. /search keeps force-dynamic (searchParams utility page).

## Verify
- npm run typecheck clean, vitest 52/52 pass
- next build: /,/about static, slugs SSG, sitemap.xml static
- Live prod-mode check: absolute self canonicals, /search?q noindex sans canonical, absolute og:image, robots allows /api/og, sitemap zero noindex URLs

## Deviations from #33
- /search stays force-dynamic (searchParams); static sitemap entries omit lastModified instead of stamping build time.