### PR TITLE
perf(seo): phase 3 CWV — next/image, cached OG fonts, deferred lightbox

### DIFF
--- a/app/api/og/route.tsx
+++ b/app/api/og/route.tsx
@@ -20,7 +20,10 @@ const KIND_LABELS = {
 
 const DEFAULT_TITLE = "Napat Pamornsut — Web Developer & Software Tester";
 
-async function loadPromptFonts() {
+// Fonts are read from disk once per server instance, not per request.
+let cachedFonts: Promise<Awaited<ReturnType<typeof readPromptFonts>>> | undefined;
+
+async function readPromptFonts() {
   const fontsDir = path.join(process.cwd(), "app", "api", "og", "fonts");
   const [regular, semiBold] = await Promise.all([
     readFile(path.join(fontsDir, "Prompt-Regular.ttf")),
@@ -30,6 +33,11 @@ async function loadPromptFonts() {
     { name: "Prompt", data: regular, weight: 400 as const, style: "normal" as const },
     { name: "Prompt", data: semiBold, weight: 600 as const, style: "normal" as const },
   ];
+}
+
+function loadPromptFonts() {
+  if (!cachedFonts) cachedFonts = readPromptFonts();
+  return cachedFonts;
 }
 
 function titleFontSize(title) {

--- a/next.config.ts
+++ b/next.config.ts
@@ -2,6 +2,16 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   reactStrictMode: true,
+  images: {
+    formats: ["image/avif", "image/webp"],
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "*.supabase.co",
+        pathname: "/storage/v1/object/**",
+      },
+    ],
+  },
 };
 
 export default nextConfig;

--- a/src/components/ui/BrandWordmark.jsx
+++ b/src/components/ui/BrandWordmark.jsx
@@ -1,6 +1,7 @@
 /**
  * BrandWordmark — โลโก้หลักของเว็บ (favicon + wordmark บรรทัดเดียว)
  */
+import Image from "next/image";
 export default function BrandWordmark({
   className = "",
   wordmarkClassName = "",
@@ -13,9 +14,11 @@ export default function BrandWordmark({
 
   if (iconOnly) {
     return (
-      <img
+      <Image
         src="/favicon.png"
         alt={title}
+        width={40}
+        height={40}
         className={`${iconSize} object-contain mix-blend-multiply flex-shrink-0 ${className}`}
       />
     );
@@ -27,10 +30,12 @@ export default function BrandWordmark({
       role="img"
       aria-label={title}
     >
-      <img
+      <Image
         src="/favicon.png"
         alt=""
         aria-hidden="true"
+        width={40}
+        height={40}
         className={`${iconSize} object-contain flex-shrink-0 mix-blend-multiply`}
       />
       <svg

--- a/src/views/About.jsx
+++ b/src/views/About.jsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import Image from "next/image";
 import { useTranslation } from "../context/LanguageContext.jsx";
 import ScrollReveal from "../components/ui/ScrollReveal.jsx";
 import PageTransition from "../components/ui/PageTransition.jsx";
@@ -148,9 +149,11 @@ export default function About({ profile }) {
                 <div className="relative flex-shrink-0">
                   <div className="absolute -inset-1 rounded-2xl bg-gradient-to-br from-[#c43c3c]/20 to-transparent blur-sm" />
                   <div className="relative flex h-24 w-24 items-center justify-center rounded-2xl border border-gray-200 bg-white p-3 shadow-[0_8px_24px_rgba(0,0,0,0.06)] md:h-28 md:w-28">
-                    <img
+                    <Image
                       src="/favicon.png"
                       alt=""
+                      width={112}
+                      height={112}
                       className="h-full w-full object-contain mix-blend-multiply"
                     />
                   </div>

--- a/src/views/ProjectDetail.jsx
+++ b/src/views/ProjectDetail.jsx
@@ -2,6 +2,8 @@
 
 import { useState, useEffect } from "react";
 import Link from "next/link";
+import Image from "next/image";
+import dynamic from "next/dynamic";
 import { useTranslation } from "../context/LanguageContext.jsx";
 import ScrollReveal from "../components/ui/ScrollReveal.jsx";
 import PageTransition from "../components/ui/PageTransition.jsx";
@@ -23,9 +25,14 @@ import "swiper/css/autoplay";
 import "swiper/css/thumbs";
 import "swiper/css/free-mode";
 
-import Lightbox from "yet-another-react-lightbox";
 import Zoom from "yet-another-react-lightbox/plugins/zoom";
 import "yet-another-react-lightbox/styles.css";
+
+// Lightbox is only needed after user interaction — split it out of the
+// initial gallery bundle.
+const Lightbox = dynamic(() => import("yet-another-react-lightbox"), {
+  ssr: false,
+});
 
 /* ========================================
    ImageGallery Component
@@ -85,12 +92,17 @@ function ImageGallery({ images, title }) {
             {images.map((img, i) => (
               <SwiperSlide key={i} className="flex items-center justify-center">
                 <div className="w-full h-full flex items-center justify-center p-2 relative group">
-                  <img
-                    src={img}
-                    alt={`${title} ${i + 1}`}
-                    className="max-h-full max-w-full object-contain select-none"
-                    draggable="false"
-                  />
+                  <div className="relative h-full w-full">
+                    <Image
+                      src={img}
+                      alt={`${title} ${i + 1}`}
+                      fill
+                      priority={i === 0}
+                      sizes="(max-width: 1024px) 100vw, 1024px"
+                      className="object-contain select-none"
+                      draggable="false"
+                    />
+                  </div>
                   {/* Zoom Hint Overlay */}
                   <div className="absolute bottom-6 right-6 bg-black/50 backdrop-blur-md text-white px-3 py-1.5 rounded-full text-xs font-bold opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none flex items-center gap-2">
                     <svg
@@ -138,10 +150,12 @@ function ImageGallery({ images, title }) {
                       : "opacity-60 hover:opacity-100"
                   }`}
                 >
-                  <img
+                  <Image
                     src={img}
                     alt={`Thumbnail ${i + 1}`}
-                    className="w-full h-full object-cover"
+                    fill
+                    sizes="(max-width: 768px) 20vw, 160px"
+                    className="object-cover"
                   />
                 </div>
               </SwiperSlide>

--- a/src/views/ProjectList.jsx
+++ b/src/views/ProjectList.jsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Link from "next/link";
+import Image from "next/image";
 import { useRouter } from "next/navigation";
 import { useTranslation } from "../context/LanguageContext.jsx";
 import ScrollReveal from "../components/ui/ScrollReveal.jsx";
@@ -130,10 +131,13 @@ function FeaturedProjectCard({ project }) {
           className="relative block min-h-[240px] overflow-hidden bg-gradient-to-br from-gray-50 to-gray-100 lg:min-h-[340px]"
           aria-label={`View ${title} case study`}
         >
-          <img
+          <Image
             src={coverImage}
             alt={title}
-            className="h-full w-full object-contain p-6 transition-transform duration-700 group-hover:scale-105"
+            fill
+            priority
+            sizes="(max-width: 1024px) 100vw, 50vw"
+            className="object-contain p-6 transition-transform duration-700 group-hover:scale-105"
           />
           <div className="absolute inset-0 bg-gradient-to-t from-gray-900/40 via-transparent to-transparent opacity-0 transition-opacity duration-500 group-hover:opacity-100" />
           <div className="absolute bottom-5 left-5 right-5 translate-y-2 opacity-0 transition-all duration-500 group-hover:translate-y-0 group-hover:opacity-100">
@@ -225,10 +229,12 @@ function ProjectCard({ project, index }) {
         <span className="absolute left-4 top-4 z-10 rounded-full bg-white/90 px-2.5 py-1 text-[11px] font-bold text-gray-500 backdrop-blur-sm">
           {String(index).padStart(2, "0")}
         </span>
-        <img
+        <Image
           src={coverImage}
           alt={title}
-          className="h-full w-full object-contain p-4 transition-transform duration-700 group-hover:scale-105"
+          fill
+          sizes="(max-width: 768px) 100vw, 50vw"
+          className="object-contain p-4 transition-transform duration-700 group-hover:scale-105"
         />
         <div className="absolute inset-0 bg-gradient-to-t from-gray-900/35 via-transparent to-transparent opacity-0 transition-opacity duration-500 group-hover:opacity-100" />
       </Link>


### PR DESCRIPTION
Closes #35. Coordinates with #30 (covers its ProjectList/ProjectDetail scope), #31, #32.

## What
- next/image migration for LCP/CLS-relevant images: ProjectList featured (priority) + cards (fill + sizes), ProjectDetail gallery + thumbs (fill + sizes), BrandWordmark + About hero fixed-size Images
- next.config.ts images: avif/webp formats + remotePatterns for Supabase Storage (SUPABASE_STORAGE_PUBLIC_BASE_URL hosts)
- /api/og fonts cached per server instance (was readFile per request)
- yet-another-react-lightbox split via next/dynamic ssr:false (gallery interactive code untouched)

## Verify
- typecheck clean, eslint 0 errors, vitest 56/56 pass, next build clean
- Live prod-mode: covers served via /_next/image optimizer, zero raw cover <img> on /projects, /api/og 200 after refactor

## Deliberately skipped (documented)
- About skill logos: decorative aria-hidden 20px jsdelivr SVGs — next/image adds nothing, avoids extra remotePatterns
- next.config redirects + custom cache headers: /_next/static immutable is Vercel default, /api/og Cache-Control already set in route handler
- Font subsets: Space Grotesk/Mono ship no Thai subset; body stack already falls back to Prompt (thai) per globals.css — no FOUT regression
- #30 remainder (admin/CMS media thumbs), #31 locale split, #32 analytics stay as separate issues