### PR TITLE
fix(seo): force static adapter during build prerender

### DIFF
--- a/src/content/repository.test.ts
+++ b/src/content/repository.test.ts
@@ -68,4 +68,13 @@ describe("StaticContentRepository contract", () => {
 
     await expect(getContentRepository()).rejects.toThrow("Production runtime must use database content storage");
   });
+
+  it("uses the static adapter at build time even when storage is database", async () => {
+    vi.stubEnv("NEXT_PHASE", "phase-production-build");
+    vi.stubEnv("CONTENT_STORAGE", "database");
+
+    const repository = await getContentRepository();
+
+    expect(repository).toBeInstanceOf(StaticContentRepository);
+  });
 });

--- a/src/content/repository.ts
+++ b/src/content/repository.ts
@@ -15,7 +15,15 @@ export function getContentRepository(): Promise<ContentRepository> {
   if (!repositoryPromise) {
     repositoryPromise = (async () => {
       const isNextBuild = process.env.NEXT_PHASE === "phase-production-build";
-      const isProductionRuntime = process.env.NODE_ENV === "production" && !isNextBuild;
+      if (isNextBuild) {
+        // Build-time prerender (SSG/ISR) must never hit the database:
+        // production env sets CONTENT_STORAGE=database and concurrent
+        // prerender queries exhaust the small pooled connection limit
+        // (Prisma P2024). Runtime ISR revalidation still reads the database.
+        const { StaticContentRepository } = await import("./static-adapter");
+        return new StaticContentRepository();
+      }
+      const isProductionRuntime = process.env.NODE_ENV === "production";
       const storage = process.env.CONTENT_STORAGE || (isProductionRuntime ? "database" : "static");
       if (isProductionRuntime && storage !== "database") {
         throw new Error("Production runtime must use database content storage");


### PR DESCRIPTION
Hotfix: Vercel build on main (f6e6504) fails with Prisma P2024 pool timeout during prerender.

Root cause: production env sets CONTENT_STORAGE=database and repository.ts let that override the build-phase check, so all 28 prerendered pages queried Supabase concurrently against connection limit 3. Pre-Phase-1 this never triggered because every page was force-dynamic (zero prerender DB access).

Fix: NEXT_PHASE=phase-production-build now always uses StaticContentRepository. Runtime ISR revalidation still reads the database; no migration, no env changes needed.

Verify: typecheck clean, vitest 57/57 (incl. new regression test), local build with CONTENT_STORAGE=database prerenders 28/28 with zero DB calls.