### PR TITLE
feat(seo): audit keywords, related links, topic hubs

### DIFF
--- a/app/notes/[slug]/page.tsx
+++ b/app/notes/[slug]/page.tsx
@@ -2,10 +2,13 @@ import type { Metadata } from "next";
 import { notFound, permanentRedirect } from "next/navigation";
 import Notes from "@/views/Notes.jsx";
 import JsonLd from "@/components/utils/JsonLd";
+import TopicHub from "@/components/notes/TopicHub.jsx";
 import { buildPageMetadata } from "@/lib/metadata";
 import { getNoteSchema, getNoteSeoMeta } from "@/lib/notes";
+import { NOTE_TOPICS, getRelatedProjects, getTopicHub, isNoteTopicKey } from "@/lib/related";
+import { SITE_URL, WEBSITE_ID, absoluteUrl, getCoreSiteSchemas } from "@/config/seo.js";
 import { getContentRepository } from "@/content/repository";
-import { toPresentationNote, toPresentationProfile } from "@/content/presentation";
+import { toPresentationNote, toPresentationProfile, toPresentationProject } from "@/content/presentation";
 
 export const revalidate = 3600;
 export const dynamicParams = true;
@@ -13,7 +16,10 @@ export const dynamicParams = true;
 export async function generateStaticParams() {
   const repository = await getContentRepository();
   const notes = await repository.listPublishedNotes();
-  return notes.map((note) => ({ slug: note.slug }));
+  return [
+    ...notes.map((note) => ({ slug: note.slug })),
+    ...Object.keys(NOTE_TOPICS).filter(isNoteTopicKey).map((topic) => ({ slug: topic })),
+  ];
 }
 
 type Props = {
@@ -22,6 +28,19 @@ type Props = {
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { slug } = await params;
+  if (isNoteTopicKey(slug)) {
+    const topic = NOTE_TOPICS[slug];
+    return buildPageMetadata({
+      title: topic.title,
+      description: topic.description,
+      ogTitle: topic.title,
+      ogDescription: topic.description,
+      ogKind: "note",
+      ogSubtitle: `โน้ตความรู้โดย Napat Pamornsut`,
+      path: `/notes/${slug}`,
+      keywords: [topic.label, `${topic.label} guide`, `Napatdev ${topic.label}`, `ณภัทร ภมรสูตร ${topic.label}`, "developer notes"],
+    });
+  }
   const repository = await getContentRepository();
   let rawNote = await repository.getPublishedNoteBySlug(slug);
   if (!rawNote) {
@@ -59,10 +78,63 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 export default async function NoteDetailPage({ params }: Props) {
   const { slug } = await params;
   const repository = await getContentRepository();
-  const [rawProfile, rawNote, rawNotes] = await Promise.all([
+  if (isNoteTopicKey(slug)) {
+    const [rawProfile, rawNotes] = await Promise.all([
+      repository.getPublishedProfile(),
+      repository.listPublishedNotes(),
+    ]);
+    const profile = toPresentationProfile(rawProfile);
+    const hubNotes = getTopicHub(slug, rawNotes.map(toPresentationNote));
+    const topic = NOTE_TOPICS[slug];
+    const hubUrl = absoluteUrl(`/notes/${slug}`);
+    return (
+      <>
+        <JsonLd
+          data={{
+            "@context": "https://schema.org",
+            "@graph": [
+              ...getCoreSiteSchemas(profile),
+              {
+                "@type": "CollectionPage",
+                "@id": `${hubUrl}#collection`,
+                url: hubUrl,
+                name: topic.title,
+                description: topic.description,
+                inLanguage: ["en", "th"],
+                isPartOf: { "@id": WEBSITE_ID },
+                mainEntity: {
+                  "@type": "ItemList",
+                  name: topic.title,
+                  numberOfItems: hubNotes.length,
+                  itemListElement: hubNotes.map((note, index) => ({
+                    "@type": "ListItem",
+                    position: index + 1,
+                    name: note.displayTitle,
+                    url: absoluteUrl(`/notes/${note.slug}`),
+                  })),
+                },
+              },
+              {
+                "@type": "BreadcrumbList",
+                "@id": `${hubUrl}#breadcrumb`,
+                itemListElement: [
+                  { "@type": "ListItem", position: 1, name: "Home / หน้าแรก", item: `${SITE_URL}/` },
+                  { "@type": "ListItem", position: 2, name: "Developer Notes / โน้ตความรู้", item: absoluteUrl("/notes") },
+                  { "@type": "ListItem", position: 3, name: topic.title, item: hubUrl },
+                ],
+              },
+            ],
+          }}
+        />
+        <TopicHub topic={topic} notes={hubNotes} />
+      </>
+    );
+  }
+  const [rawProfile, rawNote, rawNotes, rawProjects] = await Promise.all([
     repository.getPublishedProfile(),
     repository.getPublishedNoteBySlug(slug),
     repository.listPublishedNotes(),
+    repository.listPublishedProjects(),
   ]);
 
   if (!rawNote) {
@@ -74,11 +146,12 @@ export default async function NoteDetailPage({ params }: Props) {
   const profile = toPresentationProfile(rawProfile);
   const note = toPresentationNote(rawNote);
   const notes = rawNotes.map(toPresentationNote);
+  const relatedProjects = getRelatedProjects(note, rawProjects.map(toPresentationProject));
 
   return (
     <>
       <JsonLd data={getNoteSchema(note, profile)} />
-      <Notes initialNotes={notes} slug={slug} />
+      <Notes initialNotes={notes} slug={slug} relatedProjects={relatedProjects} />
     </>
   );
 }

--- a/app/notes/page.tsx
+++ b/app/notes/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import JsonLd from "@/components/utils/JsonLd";
 import { getNotesCollectionSchema, getNoteDescription } from "@/lib/notes";
+import { NOTE_TOPICS, isNoteTopicKey } from "@/lib/related";
 import { buildPageMetadata } from "@/lib/metadata";
 import { getNotesListSeoMeta } from "@/config/seo.js";
 import { getContentRepository } from "@/content/repository";
@@ -46,6 +47,18 @@ export default async function NotesIndexPage() {
           <p className="mt-4 max-w-2xl text-base font-medium leading-relaxed text-gray-500 md:text-lg">
             Practical references and lessons from Napat Pamornsut, also known as ณภัทร ภมรสูตร / Napatdev.
           </p>
+
+          <div className="mt-6 flex flex-wrap gap-2">
+            {Object.keys(NOTE_TOPICS).filter(isNoteTopicKey).map((topic) => (
+              <Link
+                key={topic}
+                href={`/notes/${topic}`}
+                className="rounded-full border border-gray-200 bg-white px-4 py-1.5 text-sm font-bold text-gray-700 transition-colors hover:border-[#c43c3c]/40 hover:text-[#c43c3c]"
+              >
+                {NOTE_TOPICS[topic].label}
+              </Link>
+            ))}
+          </div>
 
           <div className="mt-10 grid gap-4 sm:grid-cols-2">
             {notes.map((note, index) => (

--- a/app/projects/[slug]/page.tsx
+++ b/app/projects/[slug]/page.tsx
@@ -4,8 +4,9 @@ import ProjectDetail from "@/views/ProjectDetail.jsx";
 import JsonLd from "@/components/utils/JsonLd";
 import { getProjectSchema, getProjectSeoMeta } from "@/config/seo.js";
 import { buildPageMetadata } from "@/lib/metadata";
+import { getRelatedNotes } from "@/lib/related";
 import { getContentRepository } from "@/content/repository";
-import { toPresentationProfile, toPresentationProject } from "@/content/presentation";
+import { toPresentationNote, toPresentationProfile, toPresentationProject } from "@/content/presentation";
 
 export const revalidate = 3600;
 export const dynamicParams = true;
@@ -67,9 +68,10 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 export default async function ProjectDetailPage({ params }: Props) {
   const { slug } = await params;
   const repository = await getContentRepository();
-  const [rawProfile, rawProject] = await Promise.all([
+  const [rawProfile, rawProject, rawNotes] = await Promise.all([
     repository.getPublishedProfile(),
     repository.getPublishedProjectBySlug(slug),
+    repository.listPublishedNotes(),
   ]);
 
   if (!rawProject) {
@@ -80,6 +82,7 @@ export default async function ProjectDetailPage({ params }: Props) {
 
   const profile = toPresentationProfile(rawProfile);
   const project = toPresentationProject(rawProject);
+  const relatedNotes = getRelatedNotes(project, rawNotes.map(toPresentationNote));
 
   const title = project.title;
   const description = `${project.description} ${project.description_th || ""}`;
@@ -102,7 +105,7 @@ export default async function ProjectDetailPage({ params }: Props) {
           profile,
         })}
       />
-      <ProjectDetail slug={slug} project={project} />
+      <ProjectDetail slug={slug} project={project} relatedNotes={relatedNotes} />
     </>
   );
 }

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,5 +1,6 @@
 import type { MetadataRoute } from "next";
 import { SITE_URL } from "@/config/seo.js";
+import { NOTE_TOPICS, isNoteTopicKey } from "@/lib/related";
 import { getContentRepository } from "@/content/repository";
 
 export const revalidate = 3600;
@@ -44,5 +45,8 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       route(`/projects/${project.slug}`, 0.8, "monthly", project.revision.publishedAt),
     ),
     ...notes.map((note) => route(`/notes/${note.slug}`, 0.65, "monthly", note.revision.publishedAt)),
+    ...Object.keys(NOTE_TOPICS).filter(isNoteTopicKey).map((topic) =>
+      route(`/notes/${topic}`, 0.7, "weekly"),
+    ),
   ];
 }

--- a/src/components/notes/TopicHub.jsx
+++ b/src/components/notes/TopicHub.jsx
@@ -1,0 +1,47 @@
+import Link from "next/link";
+
+export default function TopicHub({ topic, notes }) {
+  return (
+    <section className="relative min-h-screen overflow-hidden bg-[#f9fafb] px-4 pb-24 pt-28 md:px-6 md:pt-32">
+      <div className="pointer-events-none absolute inset-0 bg-[linear-gradient(#e5e7eb_1px,transparent_1px),linear-gradient(90deg,#e5e7eb_1px,transparent_1px)] bg-[size:40px_40px] opacity-20 [mask-image:radial-gradient(circle_at_top,black_20%,transparent_72%)]" />
+      <div className="relative z-10 mx-auto max-w-5xl">
+        <p className="text-xs font-black uppercase tracking-[0.2em] text-[#c43c3c]">
+          Topic / หัวข้อ — {topic.label}
+        </p>
+        <h1 className="mt-3 text-4xl font-black tracking-tight text-gray-900 md:text-6xl">
+          {topic.title}
+        </h1>
+        <p className="mt-4 max-w-2xl text-base font-medium leading-relaxed text-gray-500 md:text-lg">
+          {topic.description}
+        </p>
+
+        <div className="mt-10 grid gap-4 sm:grid-cols-2">
+          {notes.map((note, index) => (
+            <Link
+              key={note.slug}
+              href={`/notes/${note.slug}`}
+              className="group rounded-2xl border border-gray-200 bg-white p-6 shadow-[0_2px_16px_rgba(0,0,0,0.04)] transition-all hover:-translate-y-1 hover:border-[#c43c3c]/30 hover:shadow-[0_16px_35px_rgba(0,0,0,0.08)]"
+            >
+              <div className="flex items-center justify-between text-[10px] font-black uppercase tracking-[0.18em] text-gray-400">
+                <span>{String(index + 1).padStart(2, "0")}</span>
+                <span className="text-[#c43c3c]">Read note</span>
+              </div>
+              <h2 className="mt-7 text-xl font-black leading-tight tracking-tight text-gray-900 transition-colors group-hover:text-[#c43c3c]">
+                {note.displayTitle}
+              </h2>
+            </Link>
+          ))}
+        </div>
+
+        <div className="mt-10">
+          <Link
+            href="/notes"
+            className="inline-flex items-center gap-2 text-sm font-bold text-gray-500 transition-colors hover:text-[#c43c3c]"
+          >
+            ← All developer notes
+          </Link>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/config/seo.js
+++ b/src/config/seo.js
@@ -89,9 +89,9 @@ export const SEO_DEFAULTS = {
 };
 
 export function getSiteSeoDefaults(profile) {
-  const defaultTitle = `${profile.name} — Web Developer & Software Tester`;
+  const defaultTitle = `${profile.name} — Web Developer & Software Tester in Bangkok`;
   const defaultDescription =
-    `Napatdev is the portfolio of ${profile.name} (ณภัทร ภมรสูตร), a Bangkok Web Developer and Software Tester focused on reliable web applications, QA, and automation testing.`;
+    `${profile.name} is a Web Developer and Software Tester based in Bangkok, Thailand, specializing in Next.js, TypeScript, full-stack development and automated testing. พอร์ตโฟลิโอของ ณภัทร ภมรสูตร นักพัฒนาเว็บและนักทดสอบซอฟต์แวร์`;
   const profileTitle = getLocalizedSeoValue(profile.seo?.title);
   const profileDescription = getLocalizedSeoValue(profile.seo?.description);
 
@@ -183,9 +183,9 @@ export function getProjectSeoMeta(project, getContent, profile) {
 
 export function getProjectsListSeoMeta(profile) {
   return {
-    title: `Web Development Projects`,
+    title: `Web Development & Software Testing Projects`,
     description: normalizeMetaDescription(
-      "Explore portfolio projects by Napat Pamornsut — web development, ERP/POS systems, IoT dashboards, automation testing, and UX/UI design. รวมผลงานโปรเจคเว็บ ระบบ POS/ERP IoT Dashboard และงานทดสอบซอฟต์แวร์",
+      "Explore full-stack web development, ERP/POS systems, IoT dashboards and software testing projects by Napat Pamornsut using Next.js, TypeScript, Prisma, Playwright and modern web technologies. รวมผลงานโปรเจคเว็บ ระบบ POS/ERP IoT Dashboard และงานทดสอบซอฟต์แวร์",
       180,
     ),
     ogImage: getRealContentImage(profile.seo?.image),

--- a/src/config/seo.test.ts
+++ b/src/config/seo.test.ts
@@ -24,7 +24,7 @@ describe("CMS SEO overrides", () => {
       seo: { title: null, description: null, image: null },
     });
 
-    expect(seo.title).toBe("Napat Pamornsut — Web Developer & Software Tester");
+    expect(seo.title).toBe("Napat Pamornsut — Web Developer & Software Tester in Bangkok");
     expect(seo.title.length).toBeLessThanOrEqual(60);
     expect(seo.description).toContain("ณภัทร ภมรสูตร");
   });

--- a/src/lib/related.test.ts
+++ b/src/lib/related.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest";
+import {
+  NOTE_TOPICS,
+  getRelatedNotes,
+  getRelatedProjects,
+  getTopicHub,
+  isNoteTopicKey,
+} from "./related";
+import type { PresentationNote, PresentationProject } from "@/content/presentation";
+
+function makeNote(overrides: Partial<PresentationNote> = {}): PresentationNote {
+  return {
+    path: "/src/data/notes/nextjs-app-router-guide.md",
+    slug: "nextjs-app-router-guide",
+    content: "# Next.js Mastery",
+    name: "Nextjs App Router Guide",
+    displayTitle: "Next.js Mastery: The Complete App Router Guide",
+    rawName: "nextjs-app-router-guide.md",
+    publishedAt: null,
+    updatedAt: null,
+    seo: { title: null, description: null },
+    ...overrides,
+  };
+}
+
+function makeProject(overrides: Partial<PresentationProject> = {}): PresentationProject {
+  return {
+    slug: "shop-inventory-management",
+    title: "Shop Inventory & Sales Management System",
+    title_th: "ระบบจัดการสต็อก",
+    images: [],
+    role: ["Full Stack"],
+    description: "Multi-tenant inventory with Next.js and Prisma",
+    description_th: "",
+    technologies: ["Next.js", "TypeScript", "Prisma", "PostgreSQL"],
+    keyFeatures: [],
+    keyFeatures_th: [],
+    highlights: [],
+    highlights_th: [],
+    responsibilities: [],
+    responsibilities_th: [],
+    links: { demo: null, repo: null },
+    featured: true,
+    metrics: [],
+    publishedAt: null,
+    updatedAt: null,
+    seo: { title: null, description: null, image: null },
+    ...overrides,
+  };
+}
+
+describe("related links", () => {
+  it("matches a Next.js note to Next.js/React projects", () => {
+    const related = getRelatedProjects(makeNote(), [
+      makeProject(),
+      makeProject({
+        slug: "clean-water-monitoring",
+        title: "Clean Water Monitoring",
+        description: "IoT water quality dashboard with Flutter",
+        technologies: ["Flutter"],
+      }),
+    ]);
+
+    expect(related.map((project) => project.slug)).toContain("shop-inventory-management");
+    expect(related.map((project) => project.slug)).not.toContain("clean-water-monitoring");
+  });
+
+  it("matches an SQL note to Prisma/PostgreSQL projects", () => {
+    const sqlNote = makeNote({
+      slug: "sql-basics",
+      name: "Sql Basics",
+      displayTitle: "SQL พื้นฐานสำหรับงานจริง",
+    });
+    const related = getRelatedProjects(sqlNote, [makeProject()]);
+
+    expect(related.map((project) => project.slug)).toEqual(["shop-inventory-management"]);
+  });
+
+  it("matches notes back from a project", () => {
+    const related = getRelatedNotes(makeProject(), [
+      makeNote(),
+      makeNote({ slug: "sql-basics", name: "Sql Basics", displayTitle: "SQL พื้นฐาน" }),
+    ]);
+
+    expect(related.map((note) => note.slug)).toContain("nextjs-app-router-guide");
+  });
+
+  it("returns empty when nothing overlaps", () => {
+    const related = getRelatedProjects(makeNote(), [
+      makeProject({ slug: "x", title: "Solar Panel Layout", description: "Rooftop panel arrangement drawings", technologies: ["AutoCAD"] }),
+    ]);
+
+    expect(related).toEqual([]);
+  });
+});
+
+describe("topic hubs", () => {
+  it("resolves hub notes in configured order for populated topics", () => {
+    const notes = [
+      makeNote({ slug: "sql-query-examples" }),
+      makeNote({ slug: "sql-basics" }),
+      makeNote(),
+    ];
+
+    expect(getTopicHub("sql", notes).map((note) => note.slug)).toEqual(["sql-basics", "sql-query-examples"]);
+    expect(getTopicHub("nextjs", notes).map((note) => note.slug)).toEqual(["nextjs-app-router-guide"]);
+  });
+
+  it("only treats populated topics as hub keys", () => {
+    expect(isNoteTopicKey("nextjs")).toBe(true);
+    expect(isNoteTopicKey("testing")).toBe(false);
+    expect(isNoteTopicKey("nope")).toBe(false);
+    expect(NOTE_TOPICS.testing.notes).toEqual([]);
+  });
+});

--- a/src/lib/related.ts
+++ b/src/lib/related.ts
@@ -1,0 +1,137 @@
+import type { PresentationNote, PresentationProject } from "@/content/presentation";
+
+// Canonical topic keys. Alias groups let a note about "Next.js" match a
+// project built with "react", or an "SQL" note match "PostgreSQL"/"Prisma".
+const TECH_ALIASES: Record<string, string[]> = {
+  nextjs: ["next.js", "nextjs", "react"],
+  typescript: ["typescript"],
+  sql: ["sql", "postgresql", "postgres", "prisma", "mysql"],
+  testing: ["playwright", "vitest", "qa", "testing", "test", "uat", "automation", "testcase", "test-case"],
+};
+
+export type NoteTopicKey = "nextjs" | "typescript" | "sql" | "testing";
+
+export const NOTE_TOPICS: Record<
+  NoteTopicKey,
+  { label: string; title: string; description: string; notes: string[] }
+> = {
+  nextjs: {
+    label: "Next.js",
+    title: "Next.js Guides & Cheatsheets",
+    description:
+      "Practical Next.js guides by Napat Pamornsut — App Router, Server Components, routing, Server Actions and data fetching. คู่มือ Next.js ฉบับใช้งานจริง",
+    notes: ["nextjs-app-router-guide"],
+  },
+  typescript: {
+    label: "TypeScript",
+    title: "TypeScript Reference & Guides",
+    description:
+      "TypeScript reference and practical guides by Napat Pamornsut — types, generics and patterns used in real projects. เอกสารอ้างอิง TypeScript",
+    notes: ["typescript-reference-guide"],
+  },
+  sql: {
+    label: "SQL",
+    title: "SQL Basics & Query Examples",
+    description:
+      "SQL fundamentals and query examples by Napat Pamornsut — basics, codes and response tables for real work. สรุป SQL พื้นฐานและตัวอย่าง query",
+    notes: ["sql-basics", "sql-query-examples"],
+  },
+  testing: {
+    label: "Testing",
+    title: "Software Testing Guides",
+    description:
+      "Software testing guides by Napat Pamornsut — Playwright automation, UAT and QA practices. คู่มือทดสอบซอฟต์แวร์",
+    notes: [],
+  },
+};
+
+function tokenize(text: string): string[] {
+  return text
+    .toLowerCase()
+    .split(/[^a-z0-9.+]+/)
+    .map((token) => token.trim())
+    .filter(Boolean);
+}
+
+function expandWithAliases(tokens: string[]): Set<string> {
+  const expanded = new Set(tokens);
+  for (const [key, aliases] of Object.entries(TECH_ALIASES)) {
+    if (tokens.some((token) => token === key || aliases.includes(token))) {
+      expanded.add(key);
+      for (const alias of aliases) expanded.add(alias);
+    }
+  }
+  return expanded;
+}
+
+function noteTokens(note: PresentationNote): Set<string> {
+  const topics = Object.entries(NOTE_TOPICS)
+    .filter(([, topic]) => topic.notes.includes(note.slug))
+    .map(([key]) => key);
+  return expandWithAliases([...topics, ...tokenize(`${note.displayTitle} ${note.name} ${note.slug}`)]);
+}
+
+function projectTokens(project: PresentationProject): Set<string> {
+  return expandWithAliases([
+    ...project.technologies.flatMap(tokenize),
+    ...tokenize(`${project.title} ${project.title_th} ${project.description}`),
+  ]);
+}
+
+function scoreOverlap(a: Set<string>, b: Set<string>): number {
+  let score = 0;
+  for (const token of a) {
+    if (b.has(token)) score += token.length > 3 ? 2 : 1;
+  }
+  return score;
+}
+
+export type RelatedProject = Pick<PresentationProject, "slug" | "title" | "title_th" | "technologies" | "featured">;
+export type RelatedNote = Pick<PresentationNote, "slug" | "displayTitle" | "name">;
+
+export function getRelatedProjects(
+  note: PresentationNote,
+  projects: PresentationProject[],
+  limit = 3,
+): RelatedProject[] {
+  const source = noteTokens(note);
+  return projects
+    .map((project) => ({ project, score: scoreOverlap(source, projectTokens(project)) }))
+    .filter(({ score }) => score > 0)
+    .sort((a, b) => b.score - a.score || Number(b.project.featured) - Number(a.project.featured))
+    .slice(0, limit)
+    .map(({ project }) => ({
+      slug: project.slug,
+      title: project.title,
+      title_th: project.title_th,
+      technologies: project.technologies,
+      featured: project.featured,
+    }));
+}
+
+export function getRelatedNotes(
+  project: PresentationProject,
+  notes: PresentationNote[],
+  limit = 3,
+): RelatedNote[] {
+  const source = projectTokens(project);
+  return notes
+    .map((note) => ({ note, score: scoreOverlap(source, noteTokens(note)) }))
+    .filter(({ score }) => score > 0)
+    .sort((a, b) => b.score - a.score)
+    .slice(0, limit)
+    .map(({ note }) => ({ slug: note.slug, displayTitle: note.displayTitle, name: note.name }));
+}
+
+export function getTopicHub(topic: NoteTopicKey, notes: PresentationNote[]): PresentationNote[] {
+  const slugs = NOTE_TOPICS[topic].notes;
+  const bySlug = new Map(notes.map((note) => [note.slug, note]));
+  return slugs.flatMap((slug) => {
+    const note = bySlug.get(slug);
+    return note ? [note] : [];
+  });
+}
+
+export function isNoteTopicKey(value: string): value is NoteTopicKey {
+  return Object.keys(NOTE_TOPICS).includes(value) && NOTE_TOPICS[value as NoteTopicKey].notes.length > 0;
+}

--- a/src/views/Notes.jsx
+++ b/src/views/Notes.jsx
@@ -11,7 +11,7 @@ import { FEATURES } from '../config/features';
 import AiSummaryPanel from '../components/notes/AiSummaryPanel';
 import AiSelectionTooltip from '../components/notes/AiSelectionTooltip';
 
-export default function Notes({ initialNotes = [], slug }) {
+export default function Notes({ initialNotes = [], slug, relatedProjects = [] }) {
   const router = useRouter();
 
   const [notes] = useState(initialNotes);
@@ -303,6 +303,37 @@ export default function Notes({ initialNotes = [], slug }) {
                   </button>
                 ) : <div className="hidden sm:block sm:w-[48%]"></div>}
               </div>
+
+              {/* Related projects — contextual internal links */}
+              {relatedProjects.length > 0 && (
+                <div className="mt-12 rounded-2xl border border-gray-200 bg-gray-50/60 p-6">
+                  <h2 className="text-sm font-black uppercase tracking-[0.18em] text-gray-500">
+                    Related projects / โปรเจคที่เกี่ยวข้อง
+                  </h2>
+                  <ul className="mt-4 space-y-3">
+                    {relatedProjects.map((project) => (
+                      <li key={project.slug}>
+                        <a
+                          href={`/projects/${project.slug}`}
+                          className="group flex items-center justify-between gap-3 rounded-xl border border-gray-200 bg-white p-4 transition-all hover:-translate-y-0.5 hover:border-[#c43c3c]/30 hover:shadow-[0_8px_20px_rgba(0,0,0,0.06)]"
+                        >
+                          <span>
+                            <span className="block font-bold text-gray-900 group-hover:text-[#c43c3c]">
+                              {project.title}
+                            </span>
+                            {project.technologies?.length > 0 && (
+                              <span className="mt-1 block text-xs font-medium text-gray-500">
+                                {project.title_th ? `${project.title_th} · ` : ""}{project.technologies.slice(0, 4).join(" · ")}
+                              </span>
+                            )}
+                          </span>
+                          <ArrowRight size={16} className="shrink-0 text-gray-400 group-hover:text-[#c43c3c]" />
+                        </a>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
 
             </div>
           ) : (

--- a/src/views/ProjectDetail.jsx
+++ b/src/views/ProjectDetail.jsx
@@ -212,7 +212,7 @@ function ListSection({ title, items }) {
   );
 }
 
-export default function ProjectDetail({ slug, project }) {
+export default function ProjectDetail({ slug, project, relatedNotes = [] }) {
   const { getContent } = useTranslation();
 
   if (!project) {
@@ -524,6 +524,30 @@ export default function ProjectDetail({ slug, project }) {
                       </div>
                     </div>
                   </ScrollReveal>
+                  {/* Related notes — contextual internal links */}
+                  {relatedNotes.length > 0 && (
+                    <ScrollReveal width="100%" delay={0.5}>
+                      <div className="pt-8 border-t border-gray-100">
+                        <h4 className="text-sm font-bold text-gray-400 uppercase tracking-widest mb-6">
+                          Related Notes
+                        </h4>
+                        <div className="flex flex-col gap-3">
+                          {relatedNotes.map((note) => (
+                            <Link
+                              key={note.slug}
+                              href={`/notes/${note.slug}`}
+                              className="group flex items-center justify-between gap-3 w-full px-5 py-4 bg-white text-gray-900 font-bold rounded-xl hover:bg-gray-50 transition-all border border-gray-200 hover:border-[#c43c3c]/30"
+                            >
+                              <span>{note.displayTitle || note.name}</span>
+                              <span className="text-sm text-gray-400 group-hover:text-[#c43c3c] transition-colors">
+                                →
+                              </span>
+                            </Link>
+                          ))}
+                        </div>
+                      </div>
+                    </ScrollReveal>
+                  )}
                 </div>{" "}
                 {/* End Sidebar */}
               </div>


### PR DESCRIPTION
Part of #40 (audit items 1, 6, 7).

## What
- Keyword-targeted defaults: home title -> Web Developer & Software Tester in Bangkok (+Next.js/TypeScript/testing description); projects list -> Web Development & Software Testing Projects
- Related-link engine (src/lib/related.ts): tech-alias keyword overlap notes<->projects, server-computed, top 3 rendered as crawlable anchors (Related projects on notes, Related Notes on projects)
- Topic hubs: NOTE_TOPICS (nextjs/typescript/sql; testing deferred until content exists) served at /notes/[topic] with unique metadata + CollectionPage/ItemList/Breadcrumb JSON-LD, topic chips on /notes index, hubs in sitemap. Empty topics never become hub routes (isNoteTopicKey).

## Verify
- typecheck clean, eslint 0 errors, vitest 65/65 (new: 6 related + hub tests)
- next build prerenders 31/31; live check: /notes/nextjs 200 self-canonical, related sections render both directions, sitemap contains 3 hubs, keyword titles live

## Required prod follow-up (human, /admin)
- Same as #41: publish slug renames so DB matches; related links + hubs then flow from DB content automatically.