### PR TITLE
Standardize bilingual SEO and Napatdev personal branding

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,3 +22,11 @@ SUPABASE_STORAGE_PUBLIC_BASE_URL=https://PROJECT_REF.supabase.co/storage/v1/obje
 # Optional public GA4 ID. Disabled when absent; visitors must opt in.
 # Disable Enhanced Measurement in this GA4 stream (manual SPA events).
 NEXT_PUBLIC_GA_MEASUREMENT_ID=
+
+# Optional webmaster verification tokens. These are rendered only when set.
+# They are verification identifiers, not API secrets.
+GOOGLE_SITE_VERIFICATION=
+BING_SITE_VERIFICATION=
+YANDEX_SITE_VERIFICATION=
+BAIDU_SITE_VERIFICATION=
+NAVER_SITE_VERIFICATION=

--- a/app/(site)/api/og/route.tsx
+++ b/app/(site)/api/og/route.tsx
@@ -19,7 +19,7 @@ const KIND_LABELS = {
   search: "Site Search",
 };
 
-const DEFAULT_TITLE = "Napat Pamornsut — Web Developer & Software Tester";
+const DEFAULT_TITLE = "Napat Pamornsut — Web Developer & Software Tester | Napatdev";
 
 // Fonts are read from disk once per server instance, not per request.
 let cachedFonts: Promise<Awaited<ReturnType<typeof readPromptFonts>>> | undefined;
@@ -111,7 +111,7 @@ export async function GET(request) {
 
         <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
           <div style={{ display: "flex", fontSize: 26, color: "#9ca3af" }}>
-            Napat Pamornsut — Web Developer & Software Tester
+            Napat Pamornsut · ณภัทร ภมรสูตร
           </div>
           <div style={{ display: "flex", width: 22, height: 22, backgroundColor: BRAND_ACCENT, borderRadius: 6 }} />
         </div>

--- a/app/(site)/layout.tsx
+++ b/app/(site)/layout.tsx
@@ -3,8 +3,8 @@ export const dynamic = "force-dynamic";
 
 import type { Metadata, Viewport } from "next";
 import AppShell from "@/components/layout/AppShell.jsx";
-import { getSiteSeoDefaults, getRealContentImage, normalizeMetaDescription, SITE_NAME, SITE_URL } from "@/config/seo.js";
-import { buildOgImageUrl } from "@/lib/metadata";
+import { getBrandedTitle, getSiteSeoDefaults, getRealContentImage, normalizeMetaDescription, SITE_NAME, SITE_URL } from "@/config/seo.js";
+import { buildOgImageUrl, getSearchEngineVerificationMeta } from "@/lib/metadata";
 import { fontVariables } from "@/lib/fonts";
 import { getContentRepository } from "@/content/repository";
 import { getNoteLocales, getProjectLocales, toPresentationProfile } from "@/content/presentation";
@@ -14,13 +14,14 @@ export async function generateMetadata(): Promise<Metadata> {
   const repository = await getContentRepository();
   const profile = toPresentationProfile(await repository.getPublishedProfile());
   const seo = getSiteSeoDefaults(profile, "en");
+  const brandedTitle = getBrandedTitle(seo.title, "en");
   const ogImage = getRealContentImage(seo.ogImage)
-    || buildOgImageUrl("site", seo.title, profile.headline);
+    || buildOgImageUrl("site", brandedTitle, profile.headline);
 
   return {
     metadataBase: new URL(SITE_URL),
     applicationName: SITE_NAME,
-    title: { default: seo.title, template: `%s | ${SITE_NAME}` },
+    title: brandedTitle,
     description: normalizeMetaDescription(seo.description, 160),
     authors: [{ name: profile.name, url: SITE_URL }],
     creator: profile.name,
@@ -30,19 +31,29 @@ export async function generateMetadata(): Promise<Metadata> {
       type: "website",
       url: SITE_URL,
       siteName: SITE_NAME,
-      title: seo.title,
+      title: brandedTitle,
       description: seo.description,
       locale: seo.locale,
       alternateLocale: [seo.alternateLocale],
       images: [{ url: ogImage, ...(getRealContentImage(seo.ogImage) ? {} : { width: 1200, height: 630 }), alt: `${profile.name} Portfolio` }],
     },
-    twitter: { card: "summary_large_image", title: seo.title, description: seo.description, images: [ogImage] },
+    twitter: { card: "summary_large_image", title: brandedTitle, description: seo.description, images: [ogImage] },
     robots: {
       index: true,
       follow: true,
-      googleBot: { index: true, follow: true, "max-image-preview": "large" },
+      googleBot: {
+        index: true,
+        follow: true,
+        "max-image-preview": "large",
+        "max-snippet": -1,
+        "max-video-preview": -1,
+      },
     },
-    other: { "geo.region": "TH-10", "geo.placename": "Bangkok" },
+    other: {
+      "geo.region": "TH-10",
+      "geo.placename": "Bangkok",
+      ...getSearchEngineVerificationMeta(),
+    },
   };
 }
 

--- a/app/manifest.ts
+++ b/app/manifest.ts
@@ -2,10 +2,10 @@ import type { MetadataRoute } from "next";
 
 export default function manifest(): MetadataRoute.Manifest {
   return {
-    name: "Napat Pamornsut (ณภัทร ภมรสูตร) | Napatdev",
+    name: "Napatdev — Napat Pamornsut (ณภัทร ภมรสูตร)",
     short_name: "Napatdev",
     description:
-      "Web Developer and Software Tester based in Bangkok, Thailand. Portfolio of React, Next.js, Node.js, Playwright projects, and technical notes. พอร์ตโฟลิโอของ ณภัทร ภมรสูตร รวมโปรเจคและโน้ตความรู้ด้านเทคนิค",
+      "Napatdev portfolio of Napat Pamornsut (ณภัทร ภมรสูตร), a Web Developer and Software Tester in Bangkok, with Next.js, TypeScript, QA automation projects, and technical notes.",
     start_url: "/",
     id: "/",
     lang: "en",

--- a/app/th/layout.tsx
+++ b/app/th/layout.tsx
@@ -3,8 +3,8 @@ export const dynamic = "force-dynamic";
 
 import type { Metadata, Viewport } from "next";
 import AppShell from "@/components/layout/AppShell.jsx";
-import { getSiteSeoDefaults, getRealContentImage, normalizeMetaDescription, SITE_NAME, SITE_URL } from "@/config/seo.js";
-import { buildOgImageUrl } from "@/lib/metadata";
+import { getBrandedTitle, getSiteSeoDefaults, getRealContentImage, normalizeMetaDescription, SITE_NAME, SITE_URL } from "@/config/seo.js";
+import { buildOgImageUrl, getSearchEngineVerificationMeta } from "@/lib/metadata";
 import { fontVariables } from "@/lib/fonts";
 import { getContentRepository } from "@/content/repository";
 import { getNoteLocales, getProjectLocales, toPresentationProfile } from "@/content/presentation";
@@ -14,13 +14,14 @@ export async function generateMetadata(): Promise<Metadata> {
   const repository = await getContentRepository();
   const profile = toPresentationProfile(await repository.getPublishedProfile());
   const seo = getSiteSeoDefaults(profile, "th");
+  const brandedTitle = getBrandedTitle(seo.title, "th");
   const ogImage = getRealContentImage(seo.ogImage)
-    || buildOgImageUrl("site", seo.title, profile.headline_th);
+    || buildOgImageUrl("site", brandedTitle, profile.headline_th);
 
   return {
     metadataBase: new URL(SITE_URL),
     applicationName: SITE_NAME,
-    title: { default: seo.title, template: `%s | ${SITE_NAME}` },
+    title: brandedTitle,
     description: normalizeMetaDescription(seo.description, 160),
     authors: [{ name: profile.name, url: SITE_URL }],
     creator: profile.name,
@@ -30,19 +31,29 @@ export async function generateMetadata(): Promise<Metadata> {
       type: "website",
       url: `${SITE_URL}/th`,
       siteName: SITE_NAME,
-      title: seo.title,
+      title: brandedTitle,
       description: seo.description,
       locale: "th_TH",
       alternateLocale: ["en_US"],
       images: [{ url: ogImage, ...(getRealContentImage(seo.ogImage) ? {} : { width: 1200, height: 630 }), alt: `${profile.name} พอร์ตโฟลิโอ` }],
     },
-    twitter: { card: "summary_large_image", title: seo.title, description: seo.description, images: [ogImage] },
+    twitter: { card: "summary_large_image", title: brandedTitle, description: seo.description, images: [ogImage] },
     robots: {
       index: true,
       follow: true,
-      googleBot: { index: true, follow: true, "max-image-preview": "large" },
+      googleBot: {
+        index: true,
+        follow: true,
+        "max-image-preview": "large",
+        "max-snippet": -1,
+        "max-video-preview": -1,
+      },
     },
-    other: { "geo.region": "TH-10", "geo.placename": "Bangkok" },
+    other: {
+      "geo.region": "TH-10",
+      "geo.placename": "Bangkok",
+      ...getSearchEngineVerificationMeta(),
+    },
   };
 }
 

--- a/e2e/seo.spec.ts
+++ b/e2e/seo.spec.ts
@@ -11,6 +11,14 @@ test.describe("public SEO", () => {
     await expect(page.locator('link[rel="canonical"]')).toHaveAttribute('href', 'https://napatdev.com/th');
     await context.close();
   });
+  test("home titles reinforce Napatdev and the localized personal name", async ({ page }) => {
+    await page.goto("/");
+    await expect(page).toHaveTitle(/Napat Pamornsut.*Napatdev/);
+
+    await page.goto("/th");
+    await expect(page).toHaveTitle(/Napatdev.*ณภัทร ภมรสูตร/);
+  });
+
   test("stored language cannot override an English URL", async ({ page }) => {
     await page.addInitScript(() => localStorage.setItem('language', 'th'));
     await page.goto('/about');

--- a/src/config/seo.js
+++ b/src/config/seo.js
@@ -1,7 +1,7 @@
 export const SITE_URL = "https://napatdev.com";
 export const SITE_NAME = "Napatdev";
 export const SITE_DESCRIPTION_EN =
-  "Napatdev is the portfolio of Napat Pamornsut, a Web Developer and Software Tester in Bangkok, Thailand, featuring web development, QA, automation testing, and technical notes.";
+  "Napatdev is the portfolio of Napat Pamornsut (ณภัทร ภมรสูตร), a Web Developer and Software Tester in Bangkok, Thailand, featuring web development, QA, automation testing, and technical notes.";
 export const SITE_DESCRIPTION_TH =
   "Napatdev พอร์ตโฟลิโอของ Napat Pamornsut (ณภัทร ภมรสูตร) นักพัฒนาเว็บและนักทดสอบซอฟต์แวร์ในกรุงเทพฯ รวมผลงานเว็บ QA การทดสอบอัตโนมัติ และโน้ตเทคนิค";
 
@@ -105,12 +105,12 @@ export function getBrandedTitle(title, locale = "en") {
 export function getSiteSeoDefaults(profile, locale = "en") {
   const defaultTitle =
     locale === "th"
-      ? "นักพัฒนาเว็บและนักทดสอบซอฟต์แวร์ กรุงเทพฯ"
+      ? `${profile.name_th || "ณภัทร ภมรสูตร"} — นักพัฒนาเว็บและนักทดสอบซอฟต์แวร์`
       : `${profile.name} — Web Developer & Software Tester`;
   const defaultDescription =
     locale === "th"
       ? `Napatdev พอร์ตโฟลิโอของ ${profile.name} (ณภัทร ภมรสูตร) นักพัฒนาเว็บและนักทดสอบซอฟต์แวร์ในกรุงเทพฯ เชี่ยวชาญ Next.js, TypeScript และการทดสอบอัตโนมัติ`
-      : `Napatdev is the portfolio of ${profile.name}, a Bangkok-based Web Developer and Software Tester focused on Next.js, TypeScript, full-stack development, and automated testing.`;
+      : `Napatdev is the portfolio of ${profile.name} (ณภัทร ภมรสูตร), a Bangkok-based Web Developer and Software Tester focused on Next.js, TypeScript, full-stack development, and automated testing.`;
   const profileTitle = stripSiteBrand(getLocalizedSeoValue(profile.seo?.title, locale));
   const profileDescription = getLocalizedSeoValue(profile.seo?.description, locale);
 
@@ -300,7 +300,7 @@ export function getPersonSchema(profile, overrides = {}) {
     "@type": "Person",
     "@id": PERSON_ID,
     name: profile.name,
-    alternateName: ["ณภัทร ภมรสูตร", "Napat Dev", "napatdev"],
+    alternateName: [profile.name_th || "ณภัทร ภมรสูตร", "Napat Pamornsut", "Napatdev"],
     url: `${SITE_URL}/`,
     image: {
       "@type": "ImageObject",
@@ -387,7 +387,13 @@ export function getWebSiteSchema(profile, overrides = {}) {
     "@type": "WebSite",
     "@id": WEBSITE_ID,
     name: SITE_NAME,
-    alternateName: [profile.name, "ณภัทร ภมรสูตร", "Napat Dev", "napatdev"],
+    alternateName: [
+      `${profile.name} Portfolio`,
+      `พอร์ตโฟลิโอ ${profile.name_th || "ณภัทร ภมรสูตร"}`,
+      profile.name,
+      profile.name_th || "ณภัทร ภมรสูตร",
+      "napatdev",
+    ],
     url: `${SITE_URL}/`,
     description: `${SITE_DESCRIPTION_EN} ${SITE_DESCRIPTION_TH}`,
     inLanguage: ["en", "th"],

--- a/src/config/seo.js
+++ b/src/config/seo.js
@@ -1,9 +1,9 @@
 export const SITE_URL = "https://napatdev.com";
 export const SITE_NAME = "Napatdev";
 export const SITE_DESCRIPTION_EN =
-  "Portfolio of Napat Pamornsut, a Web Developer and Software Tester in Bangkok, Thailand, featuring web applications, QA work, automation testing, and technical notes.";
+  "Napatdev is the portfolio of Napat Pamornsut, a Web Developer and Software Tester in Bangkok, Thailand, featuring web development, QA, automation testing, and technical notes.";
 export const SITE_DESCRIPTION_TH =
-  "พอร์ตโฟลิโอของ ณภัทร ภมรสูตร นักพัฒนาเว็บและนักทดสอบซอฟต์แวร์ รวมผลงานเว็บ งาน QA ระบบอัตโนมัติ และโน้ตความรู้ด้านเทคนิค";
+  "Napatdev พอร์ตโฟลิโอของ Napat Pamornsut (ณภัทร ภมรสูตร) นักพัฒนาเว็บและนักทดสอบซอฟต์แวร์ในกรุงเทพฯ รวมผลงานเว็บ QA การทดสอบอัตโนมัติ และโน้ตเทคนิค";
 
 export const PERSON_ID = `${SITE_URL}/#person`;
 export const WEBSITE_ID = `${SITE_URL}/#website`;
@@ -73,7 +73,7 @@ export const NAVIGATION_ITEMS = [
 ];
 
 export const SEO_DEFAULTS = {
-  title: `${SITE_NAME} | Portfolio`,
+  title: "Portfolio",
   description: `${SITE_DESCRIPTION_EN} ${SITE_DESCRIPTION_TH}`,
   ogImage: `${SITE_URL}/favicon.png`,
   locale: "en_US",
@@ -88,16 +88,30 @@ export const SEO_DEFAULTS = {
   ],
 };
 
+export function stripSiteBrand(title = "") {
+  return String(title)
+    .replace(/^\s*Napatdev\s*[|—–:-]\s*/i, "")
+    .replace(/\s*[|—–:-]\s*Napatdev\s*$/i, "")
+    .trim();
+}
+
+export function getBrandedTitle(title, locale = "en") {
+  const cleanTitle = stripSiteBrand(title) || "Portfolio";
+  return locale === "th"
+    ? `${SITE_NAME} | ${cleanTitle}`
+    : `${cleanTitle} | ${SITE_NAME}`;
+}
+
 export function getSiteSeoDefaults(profile, locale = "en") {
   const defaultTitle =
     locale === "th"
-      ? `${profile.name} — นักพัฒนาเว็บและนักทดสอบซอฟต์แวร์ กรุงเทพฯ`
-      : `${profile.name} — Web Developer & Software Tester in Bangkok`;
+      ? "นักพัฒนาเว็บและนักทดสอบซอฟต์แวร์ กรุงเทพฯ"
+      : `${profile.name} — Web Developer & Software Tester`;
   const defaultDescription =
     locale === "th"
-      ? `พอร์ตโฟลิโอของ ${profile.name} (ณภัทร ภมรสูตร) นักพัฒนาเว็บและนักทดสอบซอฟต์แวร์ในกรุงเทพฯ เชี่ยวชาญ Next.js TypeScript ฟูลสแต็กและการทดสอบอัตโนมัติ`
-      : `${profile.name} is a Web Developer and Software Tester based in Bangkok, Thailand, specializing in Next.js, TypeScript, full-stack development and automated testing. พอร์ตโฟลิโอของ ณภัทร ภมรสูตร นักพัฒนาเว็บและนักทดสอบซอฟต์แวร์`;
-  const profileTitle = getLocalizedSeoValue(profile.seo?.title, locale);
+      ? `Napatdev พอร์ตโฟลิโอของ ${profile.name} (ณภัทร ภมรสูตร) นักพัฒนาเว็บและนักทดสอบซอฟต์แวร์ในกรุงเทพฯ เชี่ยวชาญ Next.js, TypeScript และการทดสอบอัตโนมัติ`
+      : `Napatdev is the portfolio of ${profile.name}, a Bangkok-based Web Developer and Software Tester focused on Next.js, TypeScript, full-stack development, and automated testing.`;
+  const profileTitle = stripSiteBrand(getLocalizedSeoValue(profile.seo?.title, locale));
   const profileDescription = getLocalizedSeoValue(profile.seo?.description, locale);
 
   return {
@@ -372,8 +386,8 @@ export function getWebSiteSchema(profile, overrides = {}) {
   return {
     "@type": "WebSite",
     "@id": WEBSITE_ID,
-    name: `${profile.name} | ${SITE_NAME}`,
-    alternateName: ["ณภัทร ภมรสูตร", "Napat Dev", "napatdev", "พอร์ตโฟลิโอ ณภัทร"],
+    name: SITE_NAME,
+    alternateName: [profile.name, "ณภัทร ภมรสูตร", "Napat Dev", "napatdev"],
     url: `${SITE_URL}/`,
     description: `${SITE_DESCRIPTION_EN} ${SITE_DESCRIPTION_TH}`,
     inLanguage: ["en", "th"],
@@ -415,7 +429,7 @@ export function getHomeGraphSchema(profile, locale = "en") {
         "@type": "ProfilePage",
         "@id": `${absoluteUrl(locale === "th" ? "/th" : "/")}#profilepage`,
         url: absoluteUrl(locale === "th" ? "/th" : "/"),
-        name: getSiteSeoDefaults(profile, locale).title,
+        name: getBrandedTitle(seoDefaults.title, locale),
         alternateName: [`${profile.name} Portfolio`, `พอร์ตโฟลิโอ ${profile.name}`, "พอร์ตโฟลิโอ ณภัทร ภมรสูตร"],
         description: seoDefaults.description,
         inLanguage: locale,

--- a/src/config/seo.test.ts
+++ b/src/config/seo.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { getNotesListSeoMeta, getProjectSeoMeta, getSiteSeoDefaults } from "./seo.js";
+import { getBrandedTitle, getNotesListSeoMeta, getProjectSeoMeta, getSiteSeoDefaults } from "./seo.js";
 import { getNoteSeoMeta } from "@/lib/notes";
 
 describe("CMS SEO overrides", () => {
@@ -24,9 +24,19 @@ describe("CMS SEO overrides", () => {
       seo: { title: null, description: null, image: null },
     });
 
-    expect(seo.title).toBe("Napat Pamornsut — Web Developer & Software Tester in Bangkok");
+    expect(seo.title).toBe("Napat Pamornsut — Web Developer & Software Tester");
     expect(seo.title.length).toBeLessThanOrEqual(60);
+    expect(seo.description).toContain("Napat Pamornsut");
     expect(seo.description).toContain("ณภัทร ภมรสูตร");
+  });
+
+  it("builds consistent bilingual brand titles without duplicating Napatdev", () => {
+    expect(getBrandedTitle("Napat Pamornsut — Web Developer & Software Tester", "en"))
+      .toBe("Napat Pamornsut — Web Developer & Software Tester | Napatdev");
+    expect(getBrandedTitle("ณภัทร ภมรสูตร — นักพัฒนาเว็บและนักทดสอบซอฟต์แวร์", "th"))
+      .toBe("Napatdev | ณภัทร ภมรสูตร — นักพัฒนาเว็บและนักทดสอบซอฟต์แวร์");
+    expect(getBrandedTitle("Napatdev | ณภัทร ภมรสูตร — นักพัฒนาเว็บ", "th"))
+      .toBe("Napatdev | ณภัทร ภมรสูตร — นักพัฒนาเว็บ");
   });
 
   it("uses Project and Note SEO overrides for derived metadata", () => {

--- a/src/lib/metadata.test.ts
+++ b/src/lib/metadata.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { buildOgImageUrl, buildPageMetadata } from "./metadata";
+import { buildOgImageUrl, buildPageMetadata, getSearchEngineVerificationMeta } from "./metadata";
 
 describe("buildOgImageUrl", () => {
   it("encodes kind, title, and subtitle into the /api/og endpoint", () => {
@@ -99,5 +99,46 @@ describe("buildPageMetadata social image resolution", () => {
     expect(th.alternates?.canonical).toBe("https://napatdev.com/th/about");
     expect(th.alternates?.languages).toEqual(en.alternates?.languages);
     expect((th.openGraph as Record<string, unknown>).locale).toBe("th_TH");
+  });
+});
+
+describe("bilingual brand metadata", () => {
+  it("brands English titles at the end and Thai titles at the beginning", () => {
+    const en = buildPageMetadata({
+      title: "Napat Pamornsut — Web Developer & Software Tester",
+      description: "English profile",
+      path: "/",
+      locale: "en",
+    });
+    const th = buildPageMetadata({
+      title: "ณภัทร ภมรสูตร — นักพัฒนาเว็บและนักทดสอบซอฟต์แวร์",
+      description: "โปรไฟล์ภาษาไทย",
+      path: "/th",
+      locale: "th",
+    });
+
+    expect(en.title).toBe("Napat Pamornsut — Web Developer & Software Tester | Napatdev");
+    expect(th.title).toBe("Napatdev | ณภัทร ภมรสูตร — นักพัฒนาเว็บและนักทดสอบซอฟต์แวร์");
+    expect((en.openGraph as Record<string, unknown>).siteName).toBe("Napatdev");
+    expect((th.openGraph as Record<string, unknown>).siteName).toBe("Napatdev");
+  });
+
+  it("emits webmaster verification tags only when configured", () => {
+    const previous = {
+      google: process.env.GOOGLE_SITE_VERIFICATION,
+      bing: process.env.BING_SITE_VERIFICATION,
+    };
+    process.env.GOOGLE_SITE_VERIFICATION = "google-token";
+    process.env.BING_SITE_VERIFICATION = "bing-token";
+
+    expect(getSearchEngineVerificationMeta()).toMatchObject({
+      "google-site-verification": "google-token",
+      "msvalidate.01": "bing-token",
+    });
+
+    if (previous.google === undefined) delete process.env.GOOGLE_SITE_VERIFICATION;
+    else process.env.GOOGLE_SITE_VERIFICATION = previous.google;
+    if (previous.bing === undefined) delete process.env.BING_SITE_VERIFICATION;
+    else process.env.BING_SITE_VERIFICATION = previous.bing;
   });
 });

--- a/src/lib/metadata.ts
+++ b/src/lib/metadata.ts
@@ -11,6 +11,22 @@ import {
 const OG_IMAGE_WIDTH = 1200;
 const OG_IMAGE_HEIGHT = 630;
 
+const SEARCH_ENGINE_VERIFICATION_ENV = {
+  "google-site-verification": "GOOGLE_SITE_VERIFICATION",
+  "msvalidate.01": "BING_SITE_VERIFICATION",
+  "yandex-verification": "YANDEX_SITE_VERIFICATION",
+  "baidu-site-verification": "BAIDU_SITE_VERIFICATION",
+  "naver-site-verification": "NAVER_SITE_VERIFICATION",
+} as const;
+
+export function getSearchEngineVerificationMeta() {
+  return Object.fromEntries(
+    Object.entries(SEARCH_ENGINE_VERIFICATION_ENV)
+      .map(([metaName, envName]) => [metaName, process.env[envName]?.trim()])
+      .filter((entry): entry is [string, string] => Boolean(entry[1])),
+  );
+}
+
 type SeoInput = {
   title: string;
   description: string;
@@ -193,6 +209,7 @@ export function buildPageMetadata({
     other: {
       "geo.region": "TH-10",
       "geo.placename": "Bangkok",
+      ...getSearchEngineVerificationMeta(),
     },
   };
 }

--- a/src/lib/metadata.ts
+++ b/src/lib/metadata.ts
@@ -3,6 +3,7 @@ import {
   SEO_DEFAULTS,
   SITE_NAME,
   absoluteUrl,
+  getBrandedTitle,
   normalizeMetaDescription,
   toAbsoluteImageUrl,
 } from "@/config/seo.js";
@@ -112,7 +113,8 @@ export function buildPageMetadata({
   const ogLocale = isThai ? "th_TH" : SEO_DEFAULTS.locale;
   const ogAlternateLocale = isThai ? SEO_DEFAULTS.locale : SEO_DEFAULTS.alternateLocale;
   const pageDescription = normalizeMetaDescription(description, 160);
-  const effectiveTitle = ogTitle || title;
+  const brandedTitle = getBrandedTitle(title, locale);
+  const effectiveTitle = getBrandedTitle(ogTitle || title, locale);
   const effectiveDescription = normalizeMetaDescription(
     ogDescription || description,
     ogType === "article" ? 200 : 160,
@@ -153,7 +155,7 @@ export function buildPageMetadata({
   }
 
   return {
-    title,
+    title: brandedTitle,
     description: pageDescription,
     authors: [{ name: "Napat Pamornsut", url: absoluteUrl("/") }],
     creator: "Napat Pamornsut",
@@ -177,6 +179,8 @@ export function buildPageMetadata({
             index: true,
             follow: true,
             "max-image-preview": "large",
+            "max-snippet": -1,
+            "max-video-preview": -1,
           },
         },
     openGraph: openGraph as Metadata["openGraph"],

--- a/src/views/Home.jsx
+++ b/src/views/Home.jsx
@@ -73,9 +73,15 @@ export default function Home({ profile, selectedProjects = [], locale = "en" }) 
               <div>
 
 
+            <p className="mb-4 text-xs font-black uppercase tracking-[0.22em] text-accent">
+              Napatdev <span aria-hidden="true">·</span> {th ? "พอร์ตโฟลิโอ" : "Portfolio"}
+            </p>
+
             <h1 className="max-w-4xl text-[clamp(3rem,8.5vw,6rem)] font-black leading-[0.92] tracking-[-0.04em] text-gray-950">
-              {th ? profile.name_th || profile.name : profile.name}
-              <span className="sr-only"> (ณภัทร ภมรสูตร)</span>
+              {th ? profile.name_th || "ณภัทร ภมรสูตร" : profile.name}
+              <span className="sr-only">
+                {th ? ` (Napat Pamornsut)` : ` (${profile.name_th || "ณภัทร ภมรสูตร"})`}
+              </span>
             </h1>
 
             <p className="mt-6 max-w-3xl text-2xl font-black tracking-[-0.04em] text-gray-800 md:text-4xl">


### PR DESCRIPTION
Standardizes SEO identity across English and Thai around Napatdev, Napat Pamornsut, and ณภัทร ภมรสูตร. Adds locale-aware branded titles, stronger Person/WebSite schema identity, consistent OG/social branding, expanded crawler preview directives, optional verification meta support for Google/Bing/Yandex/Baidu/Naver, and regression coverage for bilingual SERP titles.